### PR TITLE
Fix PostCSS plugin usage

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import './App.css';
 import { EditableSlide } from './components/EditableSlide';
 


### PR DESCRIPTION
## Summary
- fix PostCSS config to use `tailwindcss` plugin
- remove unused `useState` import

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*