### PR TITLE
Fix PostCSS setup for Tailwind CSS v4

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,9 @@
+import tailwindcss from '@tailwindcss/postcss';
+import autoprefixer from 'autoprefixer';
+
 export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+  plugins: [
+    tailwindcss(),
+    autoprefixer(),
+  ],
 };


### PR DESCRIPTION
## Summary
- update PostCSS configuration to use `@tailwindcss/postcss`

## Testing
- `npm run build`