### PR TITLE
Add editable chart slide with autosave

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,21 @@
-# React + TypeScript + Vite
+# TrendViz Prototype
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This project demonstrates a single editable slide from **TrendViz**. It shows how users can tweak chart commentary before exporting their final presentation.
 
-Currently, two official plugins are available:
+## Features
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Chart.js line chart rendered on a 16:9 slide
+- Inline editing for the slide title and caption
+- Edits automatically saved to `localStorage`
+- Placeholder button for future AI rewrite
 
-## Expanding the ESLint configuration
+## Development
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+Install dependencies and start the development server:
 
-```js
-export default tseslint.config({
-  extends: [
-    // Remove ...tseslint.configs.recommended and replace with this
-    ...tseslint.configs.recommendedTypeChecked,
-    // Alternatively, use this for stricter rules
-    ...tseslint.configs.strictTypeChecked,
-    // Optionally, add this for stylistic rules
-    ...tseslint.configs.stylisticTypeChecked,
-  ],
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
-    'react-x': reactX,
-    'react-dom': reactDom,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended typescript rules
-    ...reactX.configs['recommended-typescript'].rules,
-    ...reactDom.configs.recommended.rules,
-  },
-})
+```bash
+npm install
+npm run dev
 ```
+
+The app will be available at `http://localhost:5173` by default.

--- a/src/components/EditableSlide.tsx
+++ b/src/components/EditableSlide.tsx
@@ -1,4 +1,5 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
+import Chart from "chart.js/auto";
 
 interface EditableSlideProps {
   initialTitle?: string;
@@ -11,6 +12,50 @@ export const EditableSlide: React.FC<EditableSlideProps> = ({
 }) => {
   const titleRef = useRef<HTMLHeadingElement>(null);
   const captionRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const [title, setTitle] = useState(initialTitle);
+  const [caption, setCaption] = useState(initialCaption);
+
+  // persist edits in localStorage
+  useEffect(() => {
+    const storedTitle = localStorage.getItem("slide-title");
+    const storedCaption = localStorage.getItem("slide-caption");
+    if (storedTitle) setTitle(storedTitle);
+    if (storedCaption) setCaption(storedCaption);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("slide-title", title);
+    localStorage.setItem("slide-caption", caption);
+  }, [title, caption]);
+
+  // render simple line chart once on mount
+  useEffect(() => {
+    if (!canvasRef.current) return;
+    const chart = new Chart(canvasRef.current, {
+      type: "line",
+      data: {
+        labels: ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+        datasets: [
+          {
+            label: "Revenue",
+            data: [3, 4, 5, 4, 6, 7],
+            borderColor: "rgb(59, 130, 246)",
+            backgroundColor: "rgba(59, 130, 246,0.4)",
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { display: false } },
+      },
+    });
+    return () => {
+      chart.destroy();
+    };
+  }, []);
 
   // Placeholder for AI rewrite (future)
   const handleRewrite = () => {
@@ -21,11 +66,8 @@ export const EditableSlide: React.FC<EditableSlideProps> = ({
   return (
     <div className="w-full max-w-4xl aspect-video bg-white rounded-xl shadow-lg flex flex-col overflow-hidden border border-gray-200">
       <div className="flex-1 flex flex-col items-center justify-center p-8">
-        {/* Chart placeholder */}
         <div className="w-full h-2/3 flex items-center justify-center mb-6">
-          <div className="w-full h-full bg-gradient-to-br from-blue-100 to-blue-300 rounded-lg flex items-center justify-center text-blue-600 font-bold text-xl border border-blue-200">
-            Chart.js Placeholder
-          </div>
+          <canvas ref={canvasRef} className="w-full h-full" />
         </div>
         {/* Editable title */}
         <h2
@@ -34,8 +76,9 @@ export const EditableSlide: React.FC<EditableSlideProps> = ({
           suppressContentEditableWarning
           className="text-2xl font-bold mb-2 outline-none focus:ring-2 focus:ring-blue-300 rounded px-2"
           data-testid="slide-title"
+          onInput={(e) => setTitle(e.currentTarget.innerText)}
         >
-          {initialTitle}
+          {title}
         </h2>
         {/* Editable caption/insight */}
         <div
@@ -44,8 +87,9 @@ export const EditableSlide: React.FC<EditableSlideProps> = ({
           suppressContentEditableWarning
           className="text-lg text-gray-700 mb-4 outline-none focus:ring-2 focus:ring-blue-200 rounded px-2 min-h-[2em]"
           data-testid="slide-caption"
+          onInput={(e) => setCaption(e.currentTarget.innerText)}
         >
-          {initialCaption}
+          {caption}
         </div>
         <div className="flex gap-2 items-center">
           <button


### PR DESCRIPTION
## Summary
- add Chart.js line chart and localStorage autosave in `EditableSlide`
- document the TrendViz prototype in the README

## Testing
- `npm run lint`
- `npm run build`
